### PR TITLE
Exclude Onebox embeds from the code-blocks with line number

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -6,7 +6,7 @@ const decorateLines = (post) => {
     const classes = ['decorator', 'number', 'scroll', 'shadow'].map(c => `lines-${c}`);
 
     const split = /^(.*)$/mg;
-    const elems = post.querySelectorAll('pre code:not(.lines-decorator)');
+    const elems = post.querySelectorAll('pre:not(.onebox) code:not(.lines-decorator)');
     elems.forEach(elem => {
       const count = elem.innerHTML.trim().match(split).length;
 


### PR DESCRIPTION
Lilly, I recently solved this issue on my theme with this little change in the selector. 

The Onebox embeds needs to be excluded from the selector used for the code blocks with line numbers. 