### PR TITLE
UX: Use ch unit to define the number section width

### DIFF
--- a/scss/formatting.scss
+++ b/scss/formatting.scss
@@ -7,7 +7,7 @@ pre.lines-decorator,
   border: 1px solid var(--primary-medium);
   background: var(--hljs-bg);
   overflow: hidden;
-  &:before {
+  &::before {
     content: "#{$code-block-header-title} " attr(data-code-wrap);
     font-family: var(--d-font-family--monospace);
     font-weight: bold;

--- a/scss/line-numbers.scss
+++ b/scss/line-numbers.scss
@@ -31,7 +31,7 @@ code {
           counter-increment: line-numbering;
           display: inline-flex;
           justify-content: flex-end;
-          min-width: 4ch;
+          width: 4ch;
           height: 100%;
           padding-left: 0.6em;
           padding-right: 0.6em;

--- a/scss/line-numbers.scss
+++ b/scss/line-numbers.scss
@@ -44,7 +44,7 @@ code {
       
       span.lines-in-quote {
         padding-left: 2em !important;
-        border-right: 0 !important;
+        border-right: none !important;
       }
       
       span.lines-count-1 {

--- a/scss/line-numbers.scss
+++ b/scss/line-numbers.scss
@@ -27,15 +27,16 @@ code {
   
       span.lines-line {
         &::before {
-          display: inline-block;
           content: counter(line-numbering);
           counter-increment: line-numbering;
-          border-right: 1px solid var(--primary-300);
-          width: 2em;
-          padding-right: 0.6em;
-          margin-right: .5em;
+          display: inline-flex;
+          justify-content: flex-end;
+          min-width: 4ch;
           height: 100%;
-          text-align: right;
+          padding-left: 0.6em;
+          padding-right: 0.6em;
+          margin-right: 0.5em;
+          border-right: 1px solid var(--primary-300);
           font-family: var(--d-font-family--monospace);
           color: var(--primary-medium);
         }
@@ -43,11 +44,11 @@ code {
       
       span.lines-in-quote {
         padding-left: 2em !important;
-        border-right: 0px !important;
+        border-right: 0 !important;
       }
       
       span.lines-count-1 {
-        margin-left: .3em;
+        margin-left: 0.3em;
       }
     }
   }


### PR DESCRIPTION
Longer code blocks with hundreds or thousands lines the number section is too narrow. We can define the width of this section with ch unit. We set it to 4ch which means it will fits to thousand number (4character).

**Before**
![Screenshot 2024-11-10 at 9 18 52](https://github.com/user-attachments/assets/d681ed45-fed8-4c66-959d-917502d69fcf) ![Screenshot 2024-11-10 at 9 23 30](https://github.com/user-attachments/assets/f8072b5f-2b41-45c0-9578-e2434c44c0ac)

**After**
![Screenshot 2024-11-10 at 9 19 36](https://github.com/user-attachments/assets/5132380d-c854-41a2-ade1-6f356938e6d9) ![Screenshot 2024-11-10 at 9 20 20](https://github.com/user-attachments/assets/052fb685-bc42-4538-a065-90e7413e2c48)


